### PR TITLE
feat: add installed optional sdk tools to path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
           mise list-all android-sdk
           mise install android-sdk@13.0
           mise exec android-sdk@13.0 -- sdkmanager --version
+          echo y | mise exec android-sdk@13.0 -- sdkmanager platform-tools
+          mise exec android-sdk@13.0 -- adb version
 
   unit-test:
     runs-on: ubuntu-latest

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -11,7 +11,7 @@ function PLUGIN:EnvKeys(ctx)
     -- Structure is: install_path/cmdline-tools/VERSION/bin
     local bin_path = file.join_path(install_path, "cmdline-tools", version, "bin")
 
-    return {
+    local env_vars = {
         {
             key = "PATH",
             value = bin_path,
@@ -25,4 +25,18 @@ function PLUGIN:EnvKeys(ctx)
             value = install_path,
         },
     }
+
+    -- Add tools installed with sdkmanager to PATH, if they exist
+    local optional_bin_paths = {"platform-tools", "emulator"}
+    for _, realtive_optional_bin_path in ipairs(optional_bin_paths) do
+        local optional_bin_path = file.join_path(install_path, realtive_optional_bin_path)
+        if file.exists(optional_bin_path) then
+            table.insert(env_vars, {
+                key = "PATH",
+                value = optional_bin_path
+            })
+        end
+    end
+
+    return env_vars
 end

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -12,7 +12,7 @@ function PLUGIN:EnvKeys(ctx)
     -- Structure is: install_path/cmdline-tools/VERSION/bin
     local bin_path = file.join_path(install_path, "cmdline-tools", version, "bin")
 
-    return {
+    local env_vars = {
         {
             key = "PATH",
             value = bin_path
@@ -26,4 +26,18 @@ function PLUGIN:EnvKeys(ctx)
             value = install_path
         }
     }
+
+    -- Add tools installed with sdkmanager to PATH, if they exist
+    local optional_bin_paths = {"platform-tools", "emulator"}
+    for _, realtive_optional_bin_path in ipairs(optional_bin_paths) do
+        local optional_bin_path = file.join_path(install_path, realtive_optional_bin_path)
+        if file.exists(optional_bin_path) then
+            table.insert(env_vars, {
+                key = "PATH",
+                value = optional_bin_path
+            })
+        end
+    end
+
+    return env_vars
 end

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -27,13 +27,13 @@ function PLUGIN:EnvKeys(ctx)
     }
 
     -- Add tools installed with sdkmanager to PATH, if they exist
-    local optional_bin_paths = {"platform-tools", "emulator"}
-    for _, realtive_optional_bin_path in ipairs(optional_bin_paths) do
-        local optional_bin_path = file.join_path(install_path, realtive_optional_bin_path)
+    local optional_bin_paths = { "platform-tools", "emulator" }
+    for _, relative_optional_bin_path in ipairs(optional_bin_paths) do
+        local optional_bin_path = file.join_path(install_path, relative_optional_bin_path)
         if file.exists(optional_bin_path) then
             table.insert(env_vars, {
                 key = "PATH",
-                value = optional_bin_path
+                value = optional_bin_path,
             })
         end
     end


### PR DESCRIPTION
## Summary
- add `platform-tools` to `PATH` when installed by `sdkmanager`
- add `emulator` to `PATH` when installed by `sdkmanager`
- preserve the command-line tools path and Android SDK environment variables

## CI
The integration matrix now installs `platform-tools` and runs `adb version` through `mise exec` on:

- Ubuntu
- macOS
- Windows

The existing unit-test job also passes.

Resolves #1.