### PR TITLE
fix: support Windows installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -27,9 +27,10 @@ jobs:
           java-version: "17"
 
       - name: Test plugin
+        shell: bash
         run: |
-          mise plugin install android-sdk https://github.com/${{ github.repository }}.git
-          mise list-all android-sdk | head -5
+          mise plugins link --force android-sdk .
+          mise list-all android-sdk
           mise install android-sdk@13.0
           mise exec android-sdk@13.0 -- sdkmanager --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@v2
+        with:
+          install: false
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -24,33 +24,34 @@ function PLUGIN:PostInstall(ctx)
     -- So we need to reorganize: move rootPath/* to rootPath/cmdline-tools/VERSION/
 
     local temp_path = root_path .. "-temp"
+    local parent_path = file.join_path(root_path, "cmdline-tools")
     local target_path = file.join_path(root_path, "cmdline-tools", version)
     local is_windows = RUNTIME.osType == "windows"
 
     if is_windows then
+        -- Remove stale temp from a previous failed install
+        os.execute('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
+
         -- Move current rootPath to temp location
         os.execute('move "' .. root_path .. '" "' .. temp_path .. '"')
 
-        -- Recreate rootPath with proper structure
-        os.execute('mkdir "' .. target_path .. '"')
+        -- Recreate parent directory structure
+        os.execute('if not exist "' .. parent_path .. '" mkdir "' .. parent_path .. '"')
 
-        -- Move contents from temp to target (/MOVE also removes temp)
-        os.execute('robocopy "' .. temp_path .. '" "' .. target_path .. '" /E /MOVE >nul')
-
-        -- Clean up temp if robocopy left it behind
-        os.execute('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
+        -- Move temp to target (renames the directory)
+        os.execute('move "' .. temp_path .. '" "' .. target_path .. '"')
     else
+        -- Remove stale temp from a previous failed install
+        os.execute('rm -rf "' .. temp_path .. '"')
+
         -- Move current rootPath to temp location
         os.execute('mv "' .. root_path .. '" "' .. temp_path .. '"')
 
-        -- Recreate rootPath with proper structure
-        os.execute('mkdir -p "' .. target_path .. '"')
+        -- Recreate parent directory structure
+        os.execute('mkdir -p "' .. parent_path .. '"')
 
-        -- Move contents from temp to target
-        os.execute('mv "' .. temp_path .. '"/* "' .. target_path .. '/"')
-
-        -- Clean up temp
-        os.execute('rm -rf "' .. temp_path .. '"')
+        -- Move temp to target (renames the directory)
+        os.execute('mv "' .. temp_path .. '" "' .. target_path .. '"')
     end
 
     -- Verify installation

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -39,10 +39,11 @@ function PLUGIN:PostInstall(ctx)
         end
 
         -- Remove stale temp from a previous failed install
-        run_powershell(
-            "Remove-Item -LiteralPath $env:TEMP_PATH -Recurse -Force -ErrorAction SilentlyContinue",
-            { TEMP_PATH = temp_path }
-        )
+        if file.exists(temp_path) then
+            run_powershell("Remove-Item -LiteralPath $env:TEMP_PATH -Recurse -Force", {
+                TEMP_PATH = temp_path,
+            })
+        end
 
         -- Move current rootPath to a temporary location
         run_powershell("Move-Item -LiteralPath $env:ROOT_PATH -Destination $env:TEMP_PATH", {

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -31,16 +31,19 @@ function PLUGIN:PostInstall(ctx)
     if is_windows then
         local cmd = require("cmd")
         local system_root = os.getenv("SystemRoot") or "C:\\Windows"
+        local robocopy = file.join_path(system_root, "System32", "robocopy.exe")
         local function run_windows(command)
             cmd.exec(command, { cwd = system_root })
         end
         local function move_contents(source, destination)
             run_windows(
-                'robocopy "'
+                robocopy
+                    .. ' "'
                     .. source
                     .. '" "'
                     .. destination
                     .. '" /e /move /nfl /ndl /njh /njs /np'
+                    .. " 1>&2"
                     .. " & if errorlevel 8 exit /b 1 & exit /b 0"
             )
         end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -26,11 +26,6 @@ function PLUGIN:PostInstall(ctx)
     local temp_path = root_path .. "-temp"
     local target_path = file.join_path(root_path, "cmdline-tools", version)
     local is_windows = RUNTIME.osType == "windows"
-    print("[android-sdk] PostInstall detected OS: " .. tostring(RUNTIME.osType) .. " (is_windows=" .. tostring(is_windows) .. ")")
-
-
-    error("Not pulling recent code")
-
 
     if is_windows then
         -- Move current rootPath to temp location

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -31,37 +31,35 @@ function PLUGIN:PostInstall(ctx)
     if is_windows then
         local cmd = require("cmd")
         local system_root = os.getenv("SystemRoot") or "C:\\Windows"
-        local robocopy = file.join_path(system_root, "System32", "robocopy.exe")
-        local function run_windows(command)
-            cmd.exec(command, { cwd = system_root })
-        end
-        local function move_contents(source, destination)
-            run_windows(
-                robocopy
-                    .. ' "'
-                    .. source
-                    .. '" "'
-                    .. destination
-                    .. '" /e /move /nfl /ndl /njh /njs /np'
-                    .. " 1>&2"
-                    .. " & if errorlevel 8 exit /b 1 & exit /b 0"
-            )
+        local function run_powershell(command, env)
+            cmd.exec("powershell.exe -NoLogo -NoProfile -NonInteractive -Command " .. command, {
+                cwd = system_root,
+                env = env,
+            })
         end
 
         -- Remove stale temp from a previous failed install
-        run_windows('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
+        run_powershell(
+            "Remove-Item -LiteralPath $env:TEMP_PATH -Recurse -Force -ErrorAction SilentlyContinue",
+            { TEMP_PATH = temp_path }
+        )
 
-        -- Move current rootPath contents to a temporary location
-        move_contents(root_path, temp_path)
+        -- Move current rootPath to a temporary location
+        run_powershell("Move-Item -LiteralPath $env:ROOT_PATH -Destination $env:TEMP_PATH", {
+            ROOT_PATH = root_path,
+            TEMP_PATH = temp_path,
+        })
 
-        -- Recreate target directory structure
-        run_windows('if not exist "' .. target_path .. '" mkdir "' .. target_path .. '"')
+        -- Recreate parent directory structure
+        run_powershell("New-Item -ItemType Directory -Force -Path $env:PARENT_PATH", {
+            PARENT_PATH = parent_path,
+        })
 
-        -- Move temporary contents into the target directory
-        move_contents(temp_path, target_path)
-
-        -- Remove the empty temporary directory
-        run_windows('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
+        -- Move temp to target (renames the directory)
+        run_powershell("Move-Item -LiteralPath $env:TEMP_PATH -Destination $env:TARGET_PATH", {
+            TEMP_PATH = temp_path,
+            TARGET_PATH = target_path,
+        })
     else
         -- Remove stale temp from a previous failed install
         os.execute('rm -rf "' .. temp_path .. '"')

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -34,18 +34,31 @@ function PLUGIN:PostInstall(ctx)
         local function run_windows(command)
             cmd.exec(command, { cwd = system_root })
         end
+        local function move_contents(source, destination)
+            run_windows(
+                'robocopy "'
+                    .. source
+                    .. '" "'
+                    .. destination
+                    .. '" /e /move /nfl /ndl /njh /njs /np'
+                    .. " & if errorlevel 8 exit /b 1 & exit /b 0"
+            )
+        end
 
         -- Remove stale temp from a previous failed install
         run_windows('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
 
-        -- Move current rootPath to temp location
-        run_windows('move "' .. root_path .. '" "' .. temp_path .. '"')
+        -- Move current rootPath contents to a temporary location
+        move_contents(root_path, temp_path)
 
-        -- Recreate parent directory structure
-        run_windows('if not exist "' .. parent_path .. '" mkdir "' .. parent_path .. '"')
+        -- Recreate target directory structure
+        run_windows('if not exist "' .. target_path .. '" mkdir "' .. target_path .. '"')
 
-        -- Move temp to target (renames the directory)
-        run_windows('move "' .. temp_path .. '" "' .. target_path .. '"')
+        -- Move temporary contents into the target directory
+        move_contents(temp_path, target_path)
+
+        -- Remove the empty temporary directory
+        run_windows('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
     else
         -- Remove stale temp from a previous failed install
         os.execute('rm -rf "' .. temp_path .. '"')

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -25,25 +25,44 @@ function PLUGIN:PostInstall(ctx)
 
     local temp_path = root_path .. "-temp"
     local target_path = file.join_path(root_path, "cmdline-tools", version)
+    local is_windows = RUNTIME.osType == "windows"
+    print("[android-sdk] PostInstall detected OS: " .. tostring(RUNTIME.osType) .. " (is_windows=" .. tostring(is_windows) .. ")")
 
-    -- Move current rootPath to temp location
-    os.execute("mv " .. root_path .. " " .. temp_path)
+    if is_windows then
+        -- Move current rootPath to temp location
+        os.execute('move "' .. root_path .. '" "' .. temp_path .. '"')
 
-    -- Recreate rootPath with proper structure
-    os.execute("mkdir -p " .. target_path)
+        -- Recreate rootPath with proper structure
+        os.execute('mkdir "' .. target_path .. '"')
 
-    -- Move contents from temp to target
-    os.execute("mv " .. temp_path .. "/* " .. target_path .. "/")
+        -- Move contents from temp to target (/MOVE also removes temp)
+        os.execute('robocopy "' .. temp_path .. '" "' .. target_path .. '" /E /MOVE >nul')
 
-    -- Clean up temp
-    os.execute("rm -rf " .. temp_path)
+        -- Clean up temp if robocopy left it behind
+        os.execute('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
+    else
+        -- Move current rootPath to temp location
+        os.execute('mv "' .. root_path .. '" "' .. temp_path .. '"')
+
+        -- Recreate rootPath with proper structure
+        os.execute('mkdir -p "' .. target_path .. '"')
+
+        -- Move contents from temp to target
+        os.execute('mv "' .. temp_path .. '"/* "' .. target_path .. '/"')
+
+        -- Clean up temp
+        os.execute('rm -rf "' .. temp_path .. '"')
+    end
 
     -- Verify installation
-    local sdkmanager_path = file.join_path(target_path, "bin", "sdkmanager")
+    local sdkmanager_name = is_windows and "sdkmanager.bat" or "sdkmanager"
+    local sdkmanager_path = file.join_path(target_path, "bin", sdkmanager_name)
     if not file.exists(sdkmanager_path) then
         error("Installation verification failed: sdkmanager not found at " .. sdkmanager_path)
     end
 
     -- Make sure binaries are executable (for Unix systems)
-    os.execute("chmod +x " .. file.join_path(target_path, "bin", "*") .. " 2>/dev/null || true")
+    if not is_windows then
+        os.execute('chmod +x "' .. file.join_path(target_path, "bin") .. '"/* 2>/dev/null || true')
+    end
 end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -28,6 +28,10 @@ function PLUGIN:PostInstall(ctx)
     local is_windows = RUNTIME.osType == "windows"
     print("[android-sdk] PostInstall detected OS: " .. tostring(RUNTIME.osType) .. " (is_windows=" .. tostring(is_windows) .. ")")
 
+
+    error("Not pulling recent code")
+
+
     if is_windows then
         -- Move current rootPath to temp location
         os.execute('move "' .. root_path .. '" "' .. temp_path .. '"')

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -29,17 +29,23 @@ function PLUGIN:PostInstall(ctx)
     local is_windows = RUNTIME.osType == "windows"
 
     if is_windows then
+        local cmd = require("cmd")
+        local system_root = os.getenv("SystemRoot") or "C:\\Windows"
+        local function run_windows(command)
+            cmd.exec(command, { cwd = system_root })
+        end
+
         -- Remove stale temp from a previous failed install
-        os.execute('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
+        run_windows('if exist "' .. temp_path .. '" rmdir /s /q "' .. temp_path .. '"')
 
         -- Move current rootPath to temp location
-        os.execute('move "' .. root_path .. '" "' .. temp_path .. '"')
+        run_windows('move "' .. root_path .. '" "' .. temp_path .. '"')
 
         -- Recreate parent directory structure
-        os.execute('if not exist "' .. parent_path .. '" mkdir "' .. parent_path .. '"')
+        run_windows('if not exist "' .. parent_path .. '" mkdir "' .. parent_path .. '"')
 
         -- Move temp to target (renames the directory)
-        os.execute('move "' .. temp_path .. '" "' .. target_path .. '"')
+        run_windows('move "' .. temp_path .. '" "' .. target_path .. '"')
     else
         -- Remove stale temp from a previous failed install
         os.execute('rm -rf "' .. temp_path .. '"')


### PR DESCRIPTION
## Summary
- add Windows support to `post_install.lua`
- handle `sdkmanager.bat` during installation verification
- pass Windows paths through environment variables to PowerShell so paths containing spaces remain safe
- quote Unix paths and keep executable permission handling Unix-only
- link the checked-out plugin in CI so pull requests test their own code

## CI
The integration matrix installs Android SDK command-line tools 13.0 and runs `sdkmanager --version` on:

- Ubuntu
- macOS
- Windows

The existing unit-test job also remains enabled.

## Issues addressed
- Resolves #3
- Resolves #8