### PR TITLE
fix: honor android sdk mirror url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
       - name: Run unit tests
-        run: ./test/run.sh
+        run: mise x lua@5.4 -- ./test/run.sh

--- a/hooks/available.lua
+++ b/hooks/available.lua
@@ -3,9 +3,8 @@
 --- @return table Descriptions of available versions and accompanying tool descriptions
 function PLUGIN:Available(ctx)
     local http = require("http")
-    local env = require("env")
 
-    local base_url = env.ANDROID_SDK_MIRROR_URL or "https://dl.google.com/android/repository"
+    local base_url = os.getenv("ANDROID_SDK_MIRROR_URL") or "https://dl.google.com/android/repository"
     local metadata_url = base_url .. "/repository2-3.xml"
 
     local resp = http.get({ url = metadata_url })

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -3,7 +3,6 @@
 --- @return table Version information
 function PLUGIN:PreInstall(ctx)
     local http = require("http")
-    local env = require("env")
 
     local version = ctx.version
 
@@ -31,7 +30,7 @@ function PLUGIN:PreInstall(ctx)
         error("Unsupported architecture: " .. arch_type)
     end
 
-    local base_url = env.ANDROID_SDK_MIRROR_URL or "https://dl.google.com/android/repository"
+    local base_url = os.getenv("ANDROID_SDK_MIRROR_URL") or "https://dl.google.com/android/repository"
     local metadata_url = base_url .. "/repository2-3.xml"
 
     local resp = http.get({ url = metadata_url })

--- a/test/mirror_url.lua
+++ b/test/mirror_url.lua
@@ -1,0 +1,38 @@
+local plugin_dir = assert(arg[1], "plugin directory argument is required")
+local mirror_url = assert(os.getenv("ANDROID_SDK_MIRROR_URL"), "mirror URL must be set")
+
+local resource = assert(io.open(plugin_dir .. "/test/resources/repository2-3.xml", "r"))
+local repository_xml = resource:read("*a")
+resource:close()
+
+local requested_urls = {}
+package.preload.http = function()
+    return {
+        get = function(options)
+            table.insert(requested_urls, options.url)
+            return {
+                status_code = 200,
+                body = repository_xml,
+            }
+        end,
+    }
+end
+
+PLUGIN = {}
+assert(loadfile(plugin_dir .. "/hooks/available.lua"))()
+local versions = PLUGIN:Available({})
+assert(#versions == 2, "available hook should parse the mirror response")
+assert(requested_urls[1] == mirror_url .. "/repository2-3.xml", "available hook ignored mirror URL")
+
+RUNTIME = {
+    osType = "linux",
+    archType = "x86_64",
+}
+PLUGIN = {}
+assert(loadfile(plugin_dir .. "/hooks/pre_install.lua"))()
+local result = PLUGIN:PreInstall({ version = "13.0" })
+assert(requested_urls[2] == mirror_url .. "/repository2-3.xml", "pre-install hook ignored mirror URL")
+assert(
+    result.url == mirror_url .. "/commandlinetools-linux-13.0.zip",
+    "pre-install hook did not resolve the download against the mirror URL"
+)

--- a/test/run.sh
+++ b/test/run.sh
@@ -70,5 +70,15 @@ if [[ ! -f "$SCRIPT_DIR/resources/repository2-3.xml" ]]; then
 fi
 echo "PASS: Test resources exist"
 
+# Test 6: Verify mirror URL handling
+echo "Test 6: Checking mirror URL handling..."
+if command -v lua &>/dev/null; then
+    ANDROID_SDK_MIRROR_URL="https://mirror.example/android" \
+        lua "$SCRIPT_DIR/mirror_url.lua" "$PLUGIN_DIR"
+    echo "PASS: Mirror URL is used by available and pre-install hooks"
+else
+    echo "SKIP: lua not available for hook tests"
+fi
+
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary
- read `ANDROID_SDK_MIRROR_URL` from the process environment in both version discovery and pre-install hooks
- resolve metadata and relative download URLs against the configured mirror
- add a mocked-hook regression test covering both hooks
- run unit tests with Lua in CI so hook behavior and syntax are actually exercised

## Root cause
The hooks attempted to read the variable from the vfox `env` module, where it was always `nil`. The vfox runtime exposes process environment variables through `os.getenv`.

## Validation
- `mise x stylua@latest -- stylua --check metadata.lua hooks test/mirror_url.lua`
- `mise x actionlint@latest -- actionlint .github/workflows/test.yml`
- `mise x lua@5.4 -- ./test/run.sh`

Resolves #6.