### PR TITLE
fix: resolve latest android sdk version numerically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,10 @@ jobs:
           echo y | mise exec android-sdk@13.0 -- sdkmanager platform-tools
           mise exec android-sdk@13.0 -- adb version
 
+      - name: Test version ordering
+        if: matrix.os == 'ubuntu-latest'
+        run: mise x lua@5.4 -- lua test/version_order.lua .
+
   unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/hooks/available.lua
+++ b/hooks/available.lua
@@ -30,9 +30,21 @@ function PLUGIN:Available(ctx)
         end
     end
 
-    -- Sort versions (simple string sort, works for numeric versions)
+    -- Android command-line tool versions are numeric and must be newest first.
+    -- vfox uses the first available version to resolve an unspecified version.
     table.sort(versions, function(a, b)
-        return a.version < b.version
+        local a_number = tonumber(a.version)
+        local b_number = tonumber(b.version)
+
+        if a_number and b_number then
+            return a_number > b_number
+        elseif a_number then
+            return true
+        elseif b_number then
+            return false
+        end
+
+        return a.version > b.version
     end)
 
     return versions

--- a/test/version_order.lua
+++ b/test/version_order.lua
@@ -1,0 +1,45 @@
+local plugin_dir = assert(arg[1], "plugin directory argument is required")
+
+local repository_xml = [[
+<sdk-repository>
+  <remotePackage path="cmdline-tools;1.0"></remotePackage>
+  <remotePackage path="cmdline-tools;9.0"></remotePackage>
+  <remotePackage path="cmdline-tools;10.0"></remotePackage>
+  <remotePackage path="cmdline-tools;22.0"></remotePackage>
+  <remotePackage path="cmdline-tools;2.1"></remotePackage>
+  <remotePackage path="cmdline-tools;latest"></remotePackage>
+</sdk-repository>
+]]
+
+package.preload.http = function()
+    return {
+        get = function()
+            return {
+                status_code = 200,
+                body = repository_xml,
+            }
+        end,
+    }
+end
+
+package.preload.env = function()
+    return {}
+end
+
+PLUGIN = {}
+assert(loadfile(plugin_dir .. "/hooks/available.lua"))()
+local versions = PLUGIN:Available({})
+local expected = { "22.0", "10.0", "9.0", "2.1", "1.0" }
+
+assert(#versions == #expected, "available hook returned an unexpected number of versions")
+for index, expected_version in ipairs(expected) do
+    assert(
+        versions[index].version == expected_version,
+        "version at index "
+            .. index
+            .. " should be "
+            .. expected_version
+            .. ", got "
+            .. tostring(versions[index].version)
+    )
+end


### PR DESCRIPTION
## Summary
- order Android command-line tool versions numerically with newest first
- keep numeric versions ahead of any unexpected nonnumeric values without treating versions as semver
- add a regression test covering `1.0`, `2.1`, `9.0`, `10.0`, and `22.0`
- run the ordering test with Lua on the Ubuntu integration job

## Root cause
The available hook sorted opaque strings lexicographically in ascending order. vfox resolves an unspecified version from the first returned entry, so `1.0` was selected while values such as `10.0` and `22.0` were ordered incorrectly. Android command-line tool releases use numeric identifiers, so this backend now applies tool-specific numeric ordering.

## Validation
- `mise x stylua@latest -- stylua --check metadata.lua hooks test/version_order.lua`
- `mise x actionlint@latest -- actionlint .github/workflows/test.yml`
- `mise x lua@5.4 -- lua test/version_order.lua .`
- isolated `mise latest android-sdk` resolves to `22.0`
- `./test/run.sh`

Resolves #5.